### PR TITLE
Fix removal of "v" characters from DOMText

### DIFF
--- a/html2text.php
+++ b/html2text.php
@@ -99,7 +99,8 @@ function prev_child_name($node) {
 
 function iterate_over_node($node) {
 	if ($node instanceof DOMText) {
-		return preg_replace("/[\\t\\n\\v\\f\\r ]+/im", " ", $node->wholeText);
+      // Replace whitespace characters with a space (equivilant to \s)
+		return preg_replace("/[\\t\\n\\f\\r ]+/im", " ", $node->wholeText);
 	}
 	if ($node instanceof DOMDocumentType) {
 		// ignore


### PR DESCRIPTION
`\t\r\n\f` are the standard whitespace characters specified.  `\v` matches a
vertical tab but support was only added in PHP 5.2.4.
(http://php.net/manual/en/regexp.reference.escape.php).  Running the test suite
on a simple string that contained a "v" character would result in all `v` characters
being stripped out of the result. (See http://cl.ly/image/3D143V0E2N0x)

Because of this oddity, I simply removed the \v.  This might not be the desired
solution, but I figured i'd open a pull.  It fixed a number of failing test cases.

I'm running on PHP 5.5.9RC1

http://cl.ly/image/470c2U1X3e0a
