### PR TITLE
Simple links

### DIFF
--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -2,13 +2,13 @@
 
 class Html2TextTest extends PHPUnit_Framework_TestCase {
 
-	function doTest($test) {
+	function doTest($test, $simple_links = false) {
 		$this->assertTrue(file_exists(__DIR__ . "/$test.html"), "File '$test.html' did not exist");
 		$this->assertTrue(file_exists(__DIR__ . "/$test.txt"), "File '$test.txt' did not exist");
 		$input = file_get_contents(__DIR__ . "/$test.html");
 		$expected = Html2Text\Html2Text::fixNewlines(file_get_contents(__DIR__ . "/$test.txt"));
 
-		$output = Html2Text\Html2Text::convert($input);
+		$output = Html2Text\Html2Text::convert($input, $simple_links);
 
 		if ($output != $expected) {
 			file_put_contents(__DIR__ . "/$test.output", $output);
@@ -38,6 +38,10 @@ class Html2TextTest extends PHPUnit_Framework_TestCase {
 
 	function testTable() {
 		$this->doTest("table");
+	}
+
+	function testAnchorsSimpleLinks() {
+		$this->doTest("anchors_simple_links", true);
 	}
 
 }

--- a/tests/anchors_simple_links.html
+++ b/tests/anchors_simple_links.html
@@ -1,0 +1,12 @@
+A document without any HTML open/closing tags.
+
+<hr>
+
+We try and use the representation given by common browsers of the 
+HTML document, so that it looks similar when converted to plain text.
+
+<a href="http://foo.com">visit foo.com</a> - or <a href="http://www.foo.com">http://www.foo.com</a>
+
+<a href="http://foo.com" title="a link with a title">link</a>
+
+<h2><a name="anchor">An anchor which will not appear</a></h2>

--- a/tests/anchors_simple_links.txt
+++ b/tests/anchors_simple_links.txt
@@ -1,0 +1,5 @@
+A document without any HTML open/closing tags.
+------
+We try and use the representation given by common browsers of the HTML document, so that it looks similar when converted to plain text. visit foo.com - or http://www.foo.com link
+
+An anchor which will not appear


### PR DESCRIPTION
convert($text, $simple_links = false)

false (default) to show links in "[ text ] ( link )" format, true to display links in "text" only format

Need to merge my other patch first.
