### PR TITLE
Stop warnings from bubbling up to error handlers.

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -40,6 +40,7 @@ class Html2Text {
 		$html = static::fixNewlines($html);
 
 		$doc = new \DOMDocument();
+        libxml_use_internal_errors(true);
 		if (!$doc->loadHTML($html)) {
 			throw new Html2TextException("Could not load HTML - badly formed?", $html);
 		}


### PR DESCRIPTION
IF this could be reviewed by someone maybe more knowledgable than me on the subject but it seemed to fix my issue. The handling is explained more clearly (and a little above my comprehension here: http://stackoverflow.com/questions/14783760/remove-dom-warning-php)
