### PR TITLE
Support elements - <b>, <strong>, <i>, <em>, <del> and <code>

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -168,6 +168,20 @@ class Html2Text {
 				$output = "- ";
 				break;
 
+			case "b":
+			case "strong":
+				$output = "**";
+				break;
+
+			case "i":
+			case "em":
+				$output = "_";
+				break;
+
+			case "del":
+				$output = "~~";
+				break;
+
 			default:
 				// print out contents of unknown tags
 				$output = "";
@@ -272,6 +286,20 @@ class Html2Text {
 
 			case "li":
 				$output .= "\n";
+				break;
+
+			case "b":
+			case "strong":
+				$output .= "**";
+				break;
+
+			case "i":
+			case "em":
+				$output .= "_";
+				break;
+
+			case "del":
+				$output .= "~~";
 				break;
 
 			default:

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -182,6 +182,10 @@ class Html2Text {
 				$output = "~~";
 				break;
 
+			case "code":
+				$output = "`";
+				break;
+
 			default:
 				// print out contents of unknown tags
 				$output = "";
@@ -300,6 +304,10 @@ class Html2Text {
 
 			case "del":
 				$output .= "~~";
+				break;
+
+			case "code":
+				$output .= "`";
 				break;
 
 			default:


### PR DESCRIPTION
Hi Jevon,

Nice library!  I've been using it in a few projects.

Here's a PR that supports a few other elements:
- `<strong>` uses two asterisks.
- `<em>` uses one underscore.  Could use the asterisk instead, but thought it might be harder to see when `<strong>` is in use.
- `<del>` uses the Github Markdown syntax of two tildes.
- `<code>` uses the <code>`</code> character.
