### PR TITLE
Made h1 to h4 tags replaced by "**"

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -140,11 +140,11 @@ class Html2Text {
 				return "";
 
 			case "h1":
-				$output = '**';
-				break;
 			case "h2":
 			case "h3":
 			case "h4":
+			$output = "\n ** ";
+			break;
 			case "h5":
 			case "h6":
 			case "ol":
@@ -195,7 +195,7 @@ class Html2Text {
 			case "h2":
 			case "h3":
 			case "h4":
-			$output .= "\n ------------------------------------------------------------";
+			$output .= "\n ------------------------------------------------------------ \n";
 			break;
 			case "h5":
 			case "h6":

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -140,6 +140,8 @@ class Html2Text {
 				return "";
 
 			case "h1":
+				$output = '**';
+				break;
 			case "h2":
 			case "h3":
 			case "h4":
@@ -193,6 +195,8 @@ class Html2Text {
 			case "h2":
 			case "h3":
 			case "h4":
+			$output .= "\n ------------------------------------------------------------";
+			break;
 			case "h5":
 			case "h6":
 				$output .= "\n";

--- a/tests/anchors.txt
+++ b/tests/anchors.txt
@@ -2,4 +2,5 @@ A document without any HTML open/closing tags.
 ---------------------------------------------------------------
 We try and use the representation given by common browsers of the HTML document, so that it looks similar when converted to plain text. [visit foo.com](http://foo.com) - or http://www.foo.com [link](http://foo.com)
 
-[An anchor which will not appear]
+** [An anchor which will not appear]
+------------------------------------------------------------

--- a/tests/basic.txt
+++ b/tests/basic.txt
@@ -1,4 +1,5 @@
-Hello, World!
+** Hello, World!
+------------------------------------------------------------
 
 This is some e-mail content. Even though it has whitespace and newlines, the e-mail converter will handle it correctly.
 

--- a/tests/full_email.txt
+++ b/tests/full_email.txt
@@ -1,7 +1,8 @@
 http://localhost/home	16 December 2015
 Account 123
 
-Hi Susan
+**  Hi Susan
+------------------------------------------------------------
 
 Here is your cat report.
 
@@ -9,11 +10,13 @@ You have found 5 cats less than anyone else
 
 [Find more cats](http://localhost/cats)
 
-Down the road
+** Down the road
+------------------------------------------------------------
 
 Across the hall
 
-Your achievements
+** Your achievements
+------------------------------------------------------------
 
 You're currently finding about
 12 cats
@@ -22,29 +25,37 @@ per day
 [Number of cats found]
 ---------------------------------------------------------------
 
-Your last cat was found two days ago.
+** Your last cat was found two days ago.
+------------------------------------------------------------
 
 One type of cat is a kitten.
 
-Special account  A1
+** Special account  A1
+------------------------------------------------------------
 
-12.345
+** 12.345
+------------------------------------------------------------
 
 http://localhost/logout
 
-How can you find more cats?
+** How can you find more cats?
+------------------------------------------------------------
 
-Look in trash cans
+** Look in trash cans
+------------------------------------------------------------
 
-Start meowing
+** Start meowing
+------------------------------------------------------------
 
-Eat cat food
+** Eat cat food
+------------------------------------------------------------
 
 Some cats like to hang out in trash cans. Some cats do not.	Some cats are attracted to similar tones.	So one day your tears may smell like cat food, attracting more cats.
 https://localhost/about	https://localhost/about	https://localhost/about
 [Cats are great.](https://github.com/soundasleep/html2text_ruby)	[Find more cats.](https://github.com/soundasleep/html2text_ruby)	[Do more things.](https://github.com/soundasleep/html2text_ruby)
 
-[Contact us](http://localhost/contact)
+**  [Contact us](http://localhost/contact)
+------------------------------------------------------------
 
 cats@cats.com
 Monday and Friday

--- a/tests/images.txt
+++ b/tests/images.txt
@@ -6,7 +6,8 @@ Three: [three]
 
 Four: [four]
 
-With links
+** With links
+------------------------------------------------------------
 
 One: http://localhost
 
@@ -16,7 +17,8 @@ Three: [three](http://localhost)
 
 Four: [four](http://localhost)
 
-With links with titles
+** With links with titles
+------------------------------------------------------------
 
 One: [one link](http://localhost)
 

--- a/tests/lists.txt
+++ b/tests/lists.txt
@@ -1,4 +1,5 @@
-List tests
+** List tests
+------------------------------------------------------------
 
 Add some lists.
 
@@ -6,7 +7,8 @@ Add some lists.
 - two
 - three
 
-An unordered list
+** An unordered list
+------------------------------------------------------------
 
 - one
 - two

--- a/tests/more-anchors.txt
+++ b/tests/more-anchors.txt
@@ -1,4 +1,5 @@
-Anchor tests
+** Anchor tests
+------------------------------------------------------------
 
 Visit http://openiaml.org or openiaml.org or http://openiaml.org.
 

--- a/tests/table.txt
+++ b/tests/table.txt
@@ -1,4 +1,5 @@
-Hello, World!
+** Hello, World!
+------------------------------------------------------------
 
 Col A	Col B
 Data A1	Data B1


### PR DESCRIPTION
`<h1>WordPress</h1>`

Becomes


```
** WordPress
------------------------------------------------------------
```


Culled from MailChimp tool (http://templates.mailchimp.com/resources/html-to-text/) and i loved it.