### PR TITLE
add blockquote support

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -56,11 +56,10 @@ class Html2Text {
 		$output = static::iterateOverNode($doc, null, false, $is_office_document);
 
 		// remove leading and trailing spaces on each line
-		$output = preg_replace("/[ \t]*\n[ \t]*/im", "\n", $output);
-		$output = preg_replace("/ *\t */im", "\t", $output);
+		$output = static::trimSpaces($output);
 
 		// unarmor pre blocks
-		$output = str_replace("\r", "\n", $output);
+		$output = static::fixNewLines($output);
 
 		// remove unnecessary empty lines
 		$output = preg_replace("/\n\n\n*/im", "\n\n", $output);
@@ -84,6 +83,20 @@ class Html2Text {
 		$text = str_replace("\r\n", "\n", $text);
 		// remove \rs
 		$text = str_replace("\r", "\n", $text);
+
+		return $text;
+	}
+
+	/**
+	 * Remove leading or trailing spaces from provided multiline text
+	 *
+	 * @param string $text multiline text any number of leading or trailing spaces
+	 * @return string the fixed text
+	 */
+	static function trimSpaces($text) {
+
+		$text = preg_replace("/[ \t]*\n[ \t]*/im", "\n", $text);
+		$text = preg_replace("/ *\t */im", "\t", $text);
 
 		return $text;
 	}
@@ -308,12 +321,12 @@ class Html2Text {
 				$output .= "\n";
 				break;
 
+			case "pre":
 			case "p":
 				// add two lines
 				$output .= "\n\n";
 				break;
 
-			case "pre":
 			case "br":
 				// add one line
 				$output .= "\n";
@@ -385,6 +398,26 @@ class Html2Text {
 				$output .= "\n";
 				break;
 
+			case "blockquote":
+
+				// remove leading and trailing spaces on each line
+				$output = static::trimSpaces($output);
+
+				// unarmor pre blocks
+				$output = static::fixNewLines($output);
+
+				// trim text, add leading newline
+				$output = "\n" . trim($output);
+
+				// prepend '> ' at the beginning of all lines
+				$output = preg_replace("/\n/im", "\n> ", $output);
+
+				// replace leading '> >' with '>>'
+				$output = preg_replace("/\n> >/im", "\n>>", $output);
+
+				// add trailing newline
+				$output .= "\n";
+				break;
 			default:
 				// do nothing
 		}

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -55,17 +55,8 @@ class Html2Text {
 
 		$output = static::iterateOverNode($doc, null, false, $is_office_document);
 
-		// remove leading and trailing spaces on each line
-		$output = static::trimSpaces($output);
-
-		// unarmor pre blocks
-		$output = static::fixNewLines($output);
-
-		// remove unnecessary empty lines
-		$output = preg_replace("/\n\n\n*/im", "\n\n", $output);
-
-		// remove leading and trailing whitespace
-		$output = trim($output);
+		// process output for whitespace/newlines
+		$output = static::processWhitespaceNewlines($output);
 
 		return $output;
 	}
@@ -88,15 +79,24 @@ class Html2Text {
 	}
 
 	/**
-	 * Remove leading or trailing spaces from provided multiline text
+	 * Remove leading or trailing spaces and excess empty lines from provided multiline text
 	 *
-	 * @param string $text multiline text any number of leading or trailing spaces
+	 * @param string $text multiline text any number of leading or trailing spaces or excess lines
 	 * @return string the fixed text
 	 */
-	static function trimSpaces($text) {
-
+	static function processWhitespaceNewlines($text) {
+		// remove leading and trailing spaces on each line
 		$text = preg_replace("/[ \t]*\n[ \t]*/im", "\n", $text);
 		$text = preg_replace("/ *\t */im", "\t", $text);
+
+		// unarmor pre blocks
+		$text = static::fixNewLines($text);
+
+		// remove unnecessary empty lines
+		$text = preg_replace("/\n\n\n*/im", "\n\n", $text);
+
+		// remove leading and trailing whitespace
+		$text = trim($text);
 
 		return $text;
 	}
@@ -235,8 +235,9 @@ class Html2Text {
 			case "h6":
 			case "ol":
 			case "ul":
-				// add two newlines, second line is added below
-				$output = "\n";
+			case "pre":
+				// add two newlines
+				$output = "\n\n";
 				break;
 
 			case "td":
@@ -261,7 +262,6 @@ class Html2Text {
 				$output = "\n\n";
 				break;
 
-			case "pre":
 			case "tr":
 			case "div":
 				// add one line
@@ -318,9 +318,6 @@ class Html2Text {
 			case "h4":
 			case "h5":
 			case "h6":
-				$output .= "\n";
-				break;
-
 			case "pre":
 			case "p":
 				// add two lines
@@ -333,6 +330,8 @@ class Html2Text {
 				break;
 
 			case "div":
+				// trim trailing newlines
+				$output = rtrim($output);
 				break;
 
 			case "a":
@@ -399,15 +398,11 @@ class Html2Text {
 				break;
 
 			case "blockquote":
+				// process quoted text for whitespace/newlines
+				$output = static::processWhitespaceNewlines($output);
 
-				// remove leading and trailing spaces on each line
-				$output = static::trimSpaces($output);
-
-				// unarmor pre blocks
-				$output = static::fixNewLines($output);
-
-				// trim text, add leading newline
-				$output = "\n" . trim($output);
+				// add leading newline
+				$output = "\n" . $output;
 
 				// prepend '> ' at the beginning of all lines
 				$output = preg_replace("/\n/im", "\n> ", $output);
@@ -415,8 +410,8 @@ class Html2Text {
 				// replace leading '> >' with '>>'
 				$output = preg_replace("/\n> >/im", "\n>>", $output);
 
-				// add trailing newline
-				$output .= "\n";
+				// add another leading newline and trailing newlines
+				$output = "\n" . $output . "\n\n";
 				break;
 			default:
 				// do nothing

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -52,6 +52,10 @@ class Html2TextTest extends PHPUnit_Framework_TestCase {
 		$this->doTest("pre");
 	}
 
+	function testBlockQuotes() {
+		$this->doTest("blockquotes");
+	}
+
 	function testFullEmail() {
 		$this->doTest("full_email");
 	}

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -52,6 +52,10 @@ class Html2TextTest extends PHPUnit_Framework_TestCase {
 		$this->doTest("pre");
 	}
 
+	function testNewLines() {
+		$this->doTest("newlines");
+	}
+
 	function testBlockQuotes() {
 		$this->doTest("blockquotes");
 	}

--- a/tests/blockquotes.html
+++ b/tests/blockquotes.html
@@ -1,0 +1,28 @@
+
+<span>Hello</span>
+<blockquote>
+Nest some block quotes with preformated text
+<blockquote>
+Here is the code
+<pre>
+#include &lt;stdlib.h&gt;
+#include &lt;stdio.h&gt;
+
+int main(){
+	return 0;
+};
+
+</pre>
+
+<b>Put some tags</b>
+<i>at the end</i>
+</blockquote>
+
+Some text <span>and tags</span> here
+
+<blockquote>
+<b>And some more tags in another quote</b>
+</blockquote>
+</blockquote>
+Some ending text
+<b>just to make sure</b>

--- a/tests/blockquotes.html
+++ b/tests/blockquotes.html
@@ -21,7 +21,22 @@ int main(){
 Some text <span>and tags</span> here
 
 <blockquote>
-<b>And some more tags in another quote</b>
+First line
+<h1>Header 1</h1>
+Some text
+<hr>
+Some more text
+<p>Paragraph tag!</p>
+<h2>Header 2</h2>
+<hr>
+<h3>Header 3</h3>
+Some text
+<h4>Header 4</h4>
+<blockquote>
+More quoted text!
+</blockquote>
+<p>Paragraph tag!</p>
+Final line
 </blockquote>
 </blockquote>
 Some ending text

--- a/tests/blockquotes.txt
+++ b/tests/blockquotes.txt
@@ -1,0 +1,15 @@
+Hello
+> Nest some block quotes with preformated text
+>> Here is the code
+>>
+>> #include <stdlib.h>
+>> #include <stdio.h>
+>>
+>> int main(){
+>>	return 0;
+>> };
+>>
+>> Put some tags at the end
+> Some text and tags here
+>> And some more tags in another quote
+Some ending text just to make sure

--- a/tests/blockquotes.txt
+++ b/tests/blockquotes.txt
@@ -1,5 +1,7 @@
 Hello
+
 > Nest some block quotes with preformated text
+>
 >> Here is the code
 >>
 >> #include <stdlib.h>
@@ -10,6 +12,33 @@ Hello
 >> };
 >>
 >> Put some tags at the end
+>
 > Some text and tags here
->> And some more tags in another quote
+>
+>> First line
+>>
+>> Header 1
+>>
+>> Some text
+>> ---------------------------------------------------------------
+>> Some more text
+>>
+>> Paragraph tag!
+>>
+>> Header 2
+>>
+>> ---------------------------------------------------------------
+>>
+>> Header 3
+>>
+>> Some text
+>>
+>> Header 4
+>>
+>>> More quoted text!
+>>
+>> Paragraph tag!
+>>
+>> Final line
+
 Some ending text just to make sure

--- a/tests/full_email.txt
+++ b/tests/full_email.txt
@@ -29,7 +29,6 @@ One type of cat is a kitten.
 Special account  A1
 
 12.345
-
 http://localhost/logout
 
 How can you find more cats?

--- a/tests/newlines.html
+++ b/tests/newlines.html
@@ -12,7 +12,6 @@ How are you?
 <p>
 How are you?
 <br>
-<p></p>
 </p>
 
 <p>

--- a/tests/newlines.html
+++ b/tests/newlines.html
@@ -20,6 +20,13 @@ How are you?
 <br>
 </p>
 
+<div>
+Just two divs
+</div>
+<div>
+Hanging out
+</div>
+
 This is not the end!
 <div>
 How are you again?
@@ -27,5 +34,18 @@ How are you again?
 </div>
 This is the end!
 <br>
+Just kidding
+<h1>Header 1</h1>
+Some text
+<hr>
+Some more text
+<p>Paragraph tag!</p>
+<h2>Header 2</h2>
+<hr>
+<h3>Header 3</h3>
+Some text
+<h4>Header 4</h4>
+<p>Paragraph tag!</p>
+Final line
 </body>
 </html>

--- a/tests/newlines.txt
+++ b/tests/newlines.txt
@@ -5,6 +5,31 @@ How are you?
 
 How are you?
 
+Just two divs
+Hanging out
 This is not the end!
 How are you again?
 This is the end!
+Just kidding
+
+Header 1
+
+Some text
+---------------------------------------------------------------
+Some more text
+
+Paragraph tag!
+
+Header 2
+
+---------------------------------------------------------------
+
+Header 3
+
+Some text
+
+Header 4
+
+Paragraph tag!
+
+Final line


### PR DESCRIPTION
Pretty self-explanatory. We use html2text to generate plaintext versions of HTML emails, among other things. Block quote tags were previously ignored, but they should not be.