### PR TITLE
Fix namespace of return type hints for DomDocument

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -32,7 +32,7 @@ class Html2Text {
 	 * @param string $html the input HTML
 	 * @param boolean $ignore_error Ignore xml parsing errors
 	 * @return string the HTML converted, as best as possible, to text
-	 * @throws Html2TextException if the HTML could not be loaded as a {@link DOMDocument}
+	 * @throws Html2TextException if the HTML could not be loaded as a {@link \DOMDocument}
 	 */
 	public static function convert($html, $ignore_error = false) {
 
@@ -117,7 +117,7 @@ class Html2Text {
 	 *
 	 * @param string $html the input HTML
 	 * @param boolean $ignore_error Ignore xml parsing errors
-	 * @return DOMDocument the parsed document tree
+	 * @return \DOMDocument the parsed document tree
 	 */
 	static function getDocument($html, $ignore_error = false) {
 


### PR DESCRIPTION
This is useful for people like me who are running static analysers on their codebases.