### PR TITLE
Add optional argument ($ignore_error) to the helper function

### DIFF
--- a/html2text.php
+++ b/html2text.php
@@ -23,8 +23,8 @@
 require_once(__DIR__ . "/src/Html2Text.php");
 require_once(__DIR__ . "/src/Html2TextException.php");
 
-function convert_html_to_text($html) {
-	return Html2Text\Html2Text::convert($html);
+function convert_html_to_text($html, $ignore_error = false) {
+	return Html2Text\Html2Text::convert($html, $ignore_error);
 }
 
 function fix_newlines($text) {


### PR DESCRIPTION
Sometimes we don't want to care about the Dom parsing errors and want to use the helper function at the same time :)