### PR TITLE
Strip out any &nbsp; in converted text

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_style = space
 indent_size = 2
 
 # don't add newlines to test files
-[spec/examples/*]
+[tests/*]
 indent_style = tabs
 trim_trailing_whitespace = false
 insert_final_newline = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - TBC
 ### Changed
 - **Important:** Changed namespace from `\Html2Text\Html2Text` to `\Soundasleep\Html2text` [#45](https://github.com/soundasleep/html2text/issues/45)
-- Convert non-breaking spaces to regular spaces to prevent output issues
+- Treat non-breaking spaces consistently: never include them in output text [#64](https://github.com/soundasleep/html2text/pull/64)
 - Optimise/improve newline & whitespace handling [#47](https://github.com/soundasleep/html2text/pull/47)
 - Upgrade PHP support to PHP 7.3+
 - Upgrade PHPUnit to 7.x

--- a/README.md
+++ b/README.md
@@ -33,10 +33,12 @@ Hello, World!
 This is some e-mail content. Even though it has whitespace and newlines, the e-mail converter will handle it correctly.
 
 Even mismatched tags.
+
 A div
 Another div
 A div
 within a div
+
 [A link](http://foo.com)
 ```
 

--- a/tests/nbsp.txt
+++ b/tests/nbsp.txt
@@ -1,1 +1,1 @@
-hello   world & people < > &NBSP;
+hello world & people < > &NBSP;


### PR DESCRIPTION
i.e, "hello &nbsp; world" should be converted to "hello world", NOT
"hello \nbsp world".

This is so the behaviour of html2text works the same as html2text_ruby.
We want to have consistent behaviour across all versions of this
component.