### PR TITLE
Allow a hash of options to be passed to html2text

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ You can also include the supplied `html2text.php` and use `$text = convert_html_
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| **ignore_errors** | `false` |Set to `true` to ignore any XML parsing errors. |
+| **ignore_errors** | `false` | Set to `true` to ignore any XML parsing errors. |
+| **drop_links** | `false` | Set to `true` to not render links as `[http://foo.com](My Link)`, but rather just `My Link`. |
 
 Pass along options as a second argument to `convert`, for example:
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ $text = \Soundasleep\Html2Text::convert($html);
 
 You can also include the supplied `html2text.php` and use `$text = convert_html_to_text($html);` instead.
 
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| **ignore_errors** | `false` |Set to `true` to ignore any XML parsing errors. |
+
+Pass along options as a second argument to `convert`, for example:
+
+```php
+$options = array(
+  'ignore_errors' => true,
+  // other options go here
+);
+$text = \Soundasleep\Html2Text::convert($html, $options);
+```
+
 ## Tests
 
 Some very basic tests are provided in the `tests/` directory. Run them with `composer install && vendor/bin/phpunit`.

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -30,7 +30,7 @@ class Html2Text {
 
 		if ($options === false || $options === true) {
 			// Using old style (< 1.0) of passing in options
-			throw new \InvalidArgumentException("html2text 1.x: Options must be passed in as an array, not as a boolean.");
+			$options = array('ignore_errors' => $options);
 		}
 
 		$options = array_merge(static::defaultOptions(), $options);

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -4,6 +4,12 @@ namespace Soundasleep;
 
 class Html2Text {
 
+	public static function defaultOptions() {
+		return array(
+			'ignore_errors' => false,
+		);
+	}
+
 	/**
 	 * Tries to convert the given HTML into a plain text format - best suited for
 	 * e-mail display, etc.
@@ -19,7 +25,21 @@ class Html2Text {
 	 * @return string the HTML converted, as best as possible, to text
 	 * @throws Html2TextException if the HTML could not be loaded as a {@link \DOMDocument}
 	 */
-	public static function convert($html, $ignore_error = false) {
+	public static function convert($html, $options = array()) {
+
+		if ($options === false || $options === true) {
+			// Using old style (< 1.0) of passing in options
+			throw new \InvalidArgumentException("html2text 1.x: Options must be passed in as an array, not as a boolean.");
+		}
+
+		$options = array_merge(static::defaultOptions(), $options);
+
+		// check all options are valid
+		foreach ($options as $key => $value) {
+			if (!in_array($key, array_keys(static::defaultOptions()))) {
+				throw new \InvalidArgumentException("Unknown html2text option '$key'");
+			}
+		}
 
 		$is_office_document = static::isOfficeDocument($html);
 
@@ -33,7 +53,7 @@ class Html2Text {
 			$html = mb_convert_encoding($html, "HTML-ENTITIES", "UTF-8");
 		}
 
-		$doc = static::getDocument($html, $ignore_error);
+		$doc = static::getDocument($html, $options['ignore_errors']);
 
 		$output = static::iterateOverNode($doc, null, false, $is_office_document);
 

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -117,10 +117,8 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		$this->doTest("invalid", array('ignore_errors' => true));
 	}
 
-	/**
-	 * @expectedException InvalidArgumentException
-	 */
 	function testInvalidXMLIgnoreOldSyntax() {
+		// for BC, allow old #convert(text, bool) syntax
 		$this->doTest("invalid", true);
 	}
 

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -5,15 +5,19 @@ require(__DIR__ . "/../src/Html2Text.php");
 class Html2TextTest extends \PHPUnit\Framework\TestCase {
 
 	function doTest($test, $options = array()) {
+		return $this->doTestWithResults($test, $test, $options);
+	}
+
+	function doTestWithResults($test, $result, $options = array()) {
 		$this->assertTrue(file_exists(__DIR__ . "/$test.html"), "File '$test.html' did not exist");
-		$this->assertTrue(file_exists(__DIR__ . "/$test.txt"), "File '$test.txt' did not exist");
+		$this->assertTrue(file_exists(__DIR__ . "/$result.txt"), "File '$result.txt' did not exist");
 		$input = file_get_contents(__DIR__ . "/$test.html");
-		$expected = \Soundasleep\Html2Text::fixNewlines(file_get_contents(__DIR__ . "/$test.txt"));
+		$expected = \Soundasleep\Html2Text::fixNewlines(file_get_contents(__DIR__ . "/$result.txt"));
 
 		$output = \Soundasleep\Html2Text::convert($input, $options);
 
 		if ($output != $expected) {
-			file_put_contents(__DIR__ . "/$test.output", $output);
+			file_put_contents(__DIR__ . "/$result.output", $output);
 		}
 		$this->assertEquals($output, $expected);
 	}
@@ -125,6 +129,14 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 	 */
 	function testInvalidOption() {
 		$this->doTest("basic", array('invalid_option' => true));
+	}
+
+	function testBasicDropLinks() {
+		$this->doTestWithResults("basic", "basic.no-links", array('drop_links' => true));
+	}
+
+	function testAnchorsDropLinks() {
+		$this->doTestWithResults("anchors", "anchors.no-links", array('drop_links' => true));
 	}
 
 }

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -4,13 +4,13 @@ require(__DIR__ . "/../src/Html2Text.php");
 
 class Html2TextTest extends \PHPUnit\Framework\TestCase {
 
-	function doTest($test, $ignoreXmlError = false) {
+	function doTest($test, $options = array()) {
 		$this->assertTrue(file_exists(__DIR__ . "/$test.html"), "File '$test.html' did not exist");
 		$this->assertTrue(file_exists(__DIR__ . "/$test.txt"), "File '$test.txt' did not exist");
 		$input = file_get_contents(__DIR__ . "/$test.html");
 		$expected = \Soundasleep\Html2Text::fixNewlines(file_get_contents(__DIR__ . "/$test.txt"));
 
-		$output = \Soundasleep\Html2Text::convert($input, $ignoreXmlError);
+		$output = \Soundasleep\Html2Text::convert($input, $options);
 
 		if ($output != $expected) {
 			file_put_contents(__DIR__ . "/$test.output", $output);
@@ -103,14 +103,28 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-     * @expectedException PHPUnit\Framework\Error\Warning
-     */
+	 * @expectedException PHPUnit\Framework\Error\Warning
+	 */
 	function testInvalidXML() {
-		$this->doTest("invalid", false);
+		$this->doTest("invalid", array('ignore_errors' => false));
 	}
 
 	function testInvalidXMLIgnore() {
+		$this->doTest("invalid", array('ignore_errors' => true));
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	function testInvalidXMLIgnoreOldSyntax() {
 		$this->doTest("invalid", true);
+	}
+
+	/**
+	 * @expectedException InvalidArgumentException
+	 */
+	function testInvalidOption() {
+		$this->doTest("basic", array('invalid_option' => true));
 	}
 
 }

--- a/tests/anchors.no-links.txt
+++ b/tests/anchors.no-links.txt
@@ -1,0 +1,5 @@
+A document without any HTML open/closing tags.
+---------------------------------------------------------------
+We try and use the representation given by common browsers of the HTML document, so that it looks similar when converted to plain text. visit foo.com - or http://www.foo.com link
+
+An anchor which will not appear

--- a/tests/basic.no-links.txt
+++ b/tests/basic.no-links.txt
@@ -1,0 +1,15 @@
+Hello, World!
+
+This is some e-mail content. Even though it has whitespace and newlines, the e-mail converter will handle it correctly.
+
+Even mismatched tags.
+
+A div
+Another div
+A div
+within a div
+
+Another line
+Yet another line
+
+A link


### PR DESCRIPTION
This will then be used to add additional options in the future.

Note, however, that we don't want to have a library with a million
options defined: we want our component behaviour to be very simple and
straightforward.