### PR TITLE
space between words closed in a tag

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -200,7 +200,7 @@ class Html2Text {
 	}
 
 	static function isWhitespace($text) {
-		return strlen(trim(static::renderText($text), "\n\r\t ")) === 0;
+		return strlen(trim(static::renderText($text), "\n\r\t")) === 0;
 	}
 
 	static function nextChildName($node) {


### PR DESCRIPTION
if there's a space between words closed in a tag, then it removes it, it shouldn't do it this way... for example you have

`<span>Name</span><span> </span><span>Surname</span> `

after the run you would get: NameSurname 

which is wrong...