### PR TITLE
Add newlines around tables

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -285,6 +285,7 @@ class Html2Text {
 			case "ol":
 			case "ul":
 			case "pre":
+                        case "table":
 				// add two newlines
 				$output = "\n\n";
 				break;
@@ -396,6 +397,7 @@ class Html2Text {
 			case "h5":
 			case "h6":
 			case "pre":
+                        case "table":
 			case "p":
 				// add two lines
 				$output .= "\n\n";

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -285,7 +285,7 @@ class Html2Text {
 			case "ol":
 			case "ul":
 			case "pre":
-                        case "table":
+			case "table":
 				// add two newlines
 				$output = "\n\n";
 				break;
@@ -397,7 +397,7 @@ class Html2Text {
 			case "h5":
 			case "h6":
 			case "pre":
-                        case "table":
+			case "table":
 			case "p":
 				// add two lines
 				$output .= "\n\n";

--- a/tests/full_email.txt
+++ b/tests/full_email.txt
@@ -19,6 +19,7 @@ You're currently finding about
 per day
 
 [Number of cats found]
+
 ---------------------------------------------------------------
 
 Your last cat was found two days ago.

--- a/tests/table.html
+++ b/tests/table.html
@@ -48,6 +48,6 @@
     </tfoot>
 
   </table>
-
+  <div>Text below</div>
 </body>
 </html>

--- a/tests/table.txt
+++ b/tests/table.txt
@@ -5,3 +5,5 @@ Data A1	Data B1
 Data A2	Data B2
 Data A3	Data B4
 Total A	Total B
+
+Text below


### PR DESCRIPTION
I think tables (especially proper ones with tabular data) should have newlines around them like paragraphs and headlines. This PR fixes this.