### PR TITLE
fix: php8 required parameter follows optional one

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -228,7 +228,7 @@ class Html2Text {
 		return $nextName;
 	}
 
-	static function iterateOverNode($node, $prevName = null, $in_pre = false, $is_office_document = false, $options) {
+	static function iterateOverNode($node, $prevName = null, $in_pre = false, $is_office_document = false, $options = []) {
 		if ($node instanceof \DOMText) {
 		  // Replace whitespace characters with a space (equivilant to \s)
 			if ($in_pre) {


### PR DESCRIPTION
Getting a deprecated error running on php8

> PHP Deprecated Warning – Required parameter $options follows optional parameter $prevName