### PR TITLE
Improve newline handling

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -404,6 +404,12 @@ class Html2Text {
 			case "ol":
 			case "ul":
 			case "p":
+				// padded paragraph handling
+				if (empty($output) && in_array($prevName, self::$margin)) {
+					$output .= "\n";
+					break;
+				}
+
 				// add two lines
 				$output .= "\n\n";
 				break;

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -10,6 +10,7 @@ class Html2Text {
 		return array(
 			'ignore_errors' => false,
 			'drop_links'    => false,
+			'lf_per_block'	=> 2,
 		);
 	}
 
@@ -319,7 +320,7 @@ class Html2Text {
 				}
 
 				// add two lines
-				$output = "\n\n";
+				$output = str_repeat("\n", $options['lf_per_block']);
 				break;
 
 			case "div":
@@ -411,7 +412,7 @@ class Html2Text {
 				}
 
 				// add two lines
-				$output .= "\n\n";
+				$output .= str_repeat("\n", $options['lf_per_block']);
 				break;
 
 			case "br":

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -19,7 +19,7 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		if ($output != $expected) {
 			file_put_contents(__DIR__ . "/$result.output", $output);
 		}
-		$this->assertEquals($output, $expected);
+		$this->assertEquals($expected, $output);
 	}
 
 	function testBasic() {
@@ -62,17 +62,17 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		$this->doTest("newlines");
 	}
 
-	function testNestedDivs() {
-		$this->doTest("nested-divs");
-	}
+//	function testNestedDivs() {
+//		$this->doTest("nested-divs");
+//	}
 
 	function testBlockQuotes() {
 		$this->doTest("blockquotes");
 	}
 
-	function testFullEmail() {
-		$this->doTest("full_email");
-	}
+//	function testFullEmail() {
+//		$this->doTest("full_email");
+//	}
 
 	function testImages() {
 		$this->doTest("images");
@@ -137,4 +137,7 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		$this->doTestWithResults("anchors", "anchors.no-links", array('drop_links' => true));
 	}
 
+    function testPaddedParagraphs() {
+        $this->doTest("padded-paragraphs");
+    }
 }

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -62,17 +62,17 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		$this->doTest("newlines");
 	}
 
-//	function testNestedDivs() {
-//		$this->doTest("nested-divs");
-//	}
+	function testNestedDivs() {
+		$this->doTest("nested-divs");
+	}
 
 	function testBlockQuotes() {
 		$this->doTest("blockquotes");
 	}
 
-//	function testFullEmail() {
-//		$this->doTest("full_email");
-//	}
+	function testFullEmail() {
+		$this->doTest("full_email");
+	}
 
 	function testImages() {
 		$this->doTest("images");

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -140,4 +140,8 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
     function testPaddedParagraphs() {
         $this->doTest("padded-paragraphs");
     }
+
+    function testLfPerBlock() {
+        $this->doTest("lf-per-block", array('lf_per_block' => 1));
+    }
 }

--- a/tests/lf-per-block.html
+++ b/tests/lf-per-block.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<p>foo</p>
+<p>&nbsp;</p>
+<p>bar</p>
+<p>quz</p>
+<p>&nbsp;</p>
+<p>qux</p>
+</body>
+</html>

--- a/tests/lf-per-block.txt
+++ b/tests/lf-per-block.txt
@@ -1,0 +1,6 @@
+foo
+
+bar
+quz
+
+qux

--- a/tests/padded-paragraphs.html
+++ b/tests/padded-paragraphs.html
@@ -1,0 +1,10 @@
+<html>
+<body>
+<p>foo</p>
+<p>&nbsp;</p>
+<p>bar</p>
+<p>quz</p>
+<p>&nbsp;</p>
+<p>qux</p>
+</body>
+</html>

--- a/tests/padded-paragraphs.txt
+++ b/tests/padded-paragraphs.txt
@@ -1,6 +1,9 @@
 foo
 
+
 bar
+
 quz
+
 
 qux

--- a/tests/padded-paragraphs.txt
+++ b/tests/padded-paragraphs.txt
@@ -1,0 +1,6 @@
+foo
+
+bar
+quz
+
+qux


### PR DESCRIPTION
* Removed new line normalisation which converted `\n{3,}` to `\n\n` - previously behaviour was frankly a hack to handle improperly outputting LFs to begin with
* Improved padded paragraph (`<p>&nbsp;</p>`) handling, output now matches that of a browser
* Added `lf-per-block` option which allows you to control how many LFs are output. For example, if you have `p { margin: 0 }` then `lf-per-block => 1` correctly matches the browser output
* Corrected parameter mismatch in `assertEquals` usage (`assertEquals($output, $expected);` should be `assertEquals($expected, $output);`)

Closes #94 