### PR TITLE
Support extracting the raw URL from the HTML href attribute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
     name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
     steps:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can also include the supplied `html2text.php` and use `$text = convert_html_
 | Option | Default | Description |
 |--------|---------|-------------|
 | **ignore_errors** | `false` | Set to `true` to ignore any XML parsing errors. |
-| **drop_links** | `false` | Set to `true` to not render links as `[http://foo.com](My Link)`, but rather just `My Link`. |
+| **drop_links** | `false` | Set to `true` to not render links as `[http://foo.com](My Link)`, but rather just `My Link`. Set to `'href'` to return the URL instead of the name.|
 | **char_set** | `'auto'` | Specify a specific character set.  Pass multiple character sets (comma separated) to detect encoding, default is ASCII,UTF-8 |
 
 Pass along options as a second argument to `convert`, for example:

--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -477,7 +477,9 @@ class Html2Text {
 					} else {
 						// replace it
 						if ($output) {
-							if ($options['drop_links']) {
+							if ($options['drop_links'] === 'href') {
+								$output = str_replace(' ', '+', $href);
+							} elseif ($options['drop_links']) {
 								$output = "$output";
 							} else {
 								$output = "[$output]($href)";

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -91,6 +91,14 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 		$this->doTestWithResults("anchors", "anchors.no-links", ['drop_links' => true]);
 	}
 
+	public function testBasicHRefLinks(): void {
+		$this->doTestWithResults("basic", "basic.href-links", ['drop_links' => 'href']);
+	}
+
+	public function testAnchorsHRefLinks(): void {
+		$this->doTestWithResults("anchors", "anchors.href-links", ['drop_links' => 'href']);
+	}
+
 	public function testWindows1252(): void {
 		$this->doTestWithResults("windows-1252-example", "windows-1252-example", ['char_set' => 'windows-1252']);
 	}

--- a/tests/Html2TextTest.php
+++ b/tests/Html2TextTest.php
@@ -38,7 +38,7 @@ class Html2TextTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/** @return array<array<string>> */
-	public function providerFiles(): array {
+	public static function providerFiles(): array {
 		return [
 			['basic'],
 			['anchors'],

--- a/tests/txt/anchors.href-links.txt
+++ b/tests/txt/anchors.href-links.txt
@@ -1,0 +1,5 @@
+A document without any HTML open/closing tags.
+---------------------------------------------------------------
+We try and use the representation given by common browsers of the HTML document, so that it looks similar when converted to plain text. http://foo.com - or http://www.foo.com http://foo.com
+
+An anchor which will not appear

--- a/tests/txt/basic.href-links.txt
+++ b/tests/txt/basic.href-links.txt
@@ -1,0 +1,15 @@
+Hello, World!
+
+This is some e-mail content. Even though it has whitespace and newlines, the e-mail converter will handle it correctly.
+
+Even mismatched tags.
+
+A div
+Another div
+A div
+within a div
+
+Another line
+Yet another line
+
+http://foo.com


### PR DESCRIPTION
Often you just need the raw URL from an A tag.  Added the parameter 'href' to the drop_links to return just the raw URL. Email clients like Gmail will correctly process raw URLs, so this can be useful when returning markup is not desired.

Also updated the tests for PHP 8.3 and fixed a static warning.