### PR TITLE
Exclude non-essential files from distributed package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Folders
+.github/ export-ignore
+tests/   export-ignore
+
+# Files
+.editorconfig     export-ignore
+.gitignore        export-ignore
+.gitattributes    export-ignore
+phpstan.neon.dist export-ignore
+phpunit.xml       export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Exclude non-essential files from distributed package [#110](https://github.com/soundasleep/html2text/pull/110)
 
 ## [1.1.0] - 2019-02-15
 ### Added


### PR DESCRIPTION
Fixes #107

Introduce a `.gitattributes` file to indicate a list of directories or files that do not need to be added when requiring a stable version of the package.